### PR TITLE
Specify a default auto field type for models

### DIFF
--- a/ww/settings.py
+++ b/ww/settings.py
@@ -69,6 +69,8 @@ DATABASES = {
     }
 }
 
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
+
 
 LANGUAGE_CODE = 'en-us'
 TIME_ZONE = 'UTC'


### PR DESCRIPTION
Django 3.2 shows a warning for models missing an explicit primary key type